### PR TITLE
Group context

### DIFF
--- a/lib/controller/BassRestController.js
+++ b/lib/controller/BassRestController.js
@@ -171,7 +171,7 @@ module.exports = class BassRestController extends RestController {
             const data = this.specification.deserializeRequestData(
                 req,
                 this.resourceType,
-                this.getGroupContext()
+                this.getGroupContext(req, res)
             );
 
             if (Array.isArray(data)) {
@@ -369,7 +369,7 @@ module.exports = class BassRestController extends RestController {
             const data = this.specification.deserializeRequestData(
                 req,
                 this.resourceType,
-                this.getGroupContext()
+                this.getGroupContext(req, res)
             );
 
             this.patchSingle(req, res, session, manager, data, req.params.id).then((resource) => {
@@ -602,7 +602,7 @@ module.exports = class BassRestController extends RestController {
                     const data = this.specification.deserializeRequestData(
                         req,
                         this.resourceType,
-                        this.getGroupContext()
+                        this.getGroupContext(req, res)
                     );
 
                     // attach any relationships
@@ -692,7 +692,7 @@ module.exports = class BassRestController extends RestController {
             const data = this.specification.deserializeRequestData(
                 req,
                 this.resourceType,
-                this.getGroupContext()
+                this.getGroupContext(req, res)
             );
 
             const promises = [];
@@ -838,7 +838,7 @@ module.exports = class BassRestController extends RestController {
             const data = this.specification.deserializeRequestData(
                 req,
                 this.resourceType,
-                this.getGroupContext()
+                this.getGroupContext(req, res)
             );
 
             const promises = [];

--- a/lib/controller/BassRestController.js
+++ b/lib/controller/BassRestController.js
@@ -224,13 +224,17 @@ module.exports = class BassRestController extends RestController {
 
                     manager.flush().then(() => {
 
-                        return this.sendSuccessResponse(
-                            req,
-                            res,
-                            resource,
-                            null,
-                            201
-                        );
+                       return this.onPostCreate(req, res, resource, session, manager).then(() => {
+
+                            return this.sendSuccessResponse(
+                                req,
+                                res,
+                                resource,
+                                null,
+                                201
+                            );
+
+                        });
 
                     }).catch((error) => {
                         return this.sendInternalServerError(res, error);

--- a/lib/controller/RestController.js
+++ b/lib/controller/RestController.js
@@ -279,7 +279,7 @@ module.exports = class RestController extends Controller {
         const returnData = {
             context: this.getGroupContext(req, res),
             type: this.resourceType,
-            route: req.conga.route,
+            route: req.route,
             data: data,
             pager: pager,
             includes: this.parseIncludes(req, res),

--- a/lib/controller/RestController.js
+++ b/lib/controller/RestController.js
@@ -276,9 +276,8 @@ module.exports = class RestController extends Controller {
      * @return {Object}              [description]
      */
     buildReturnData(req, res, data, pager = null) {
-
-        return {
-            context: this.getGroupContext(),
+        const returnData = {
+            context: this.getGroupContext(req, res),
             type: this.resourceType,
             route: req.conga.route,
             data: data,
@@ -286,7 +285,20 @@ module.exports = class RestController extends Controller {
             includes: this.parseIncludes(req, res),
             sparse: this.parseSparse(req, res)
         };
+        this.onBuildReturnData(req, res, returnData);
+        return returnData;
+    }
 
+    /**
+     * Override this method if you want to manipulate the return data before the response is sent
+     *
+     * @param {Object} req
+     * @param {Object} res
+     * @param {Object} returnData
+     * @returns {void}
+     */
+    onBuildReturnData(req, res, returnData) {
+        // empty
     }
 
     /**

--- a/lib/specification/RestNormalizer.js
+++ b/lib/specification/RestNormalizer.js
@@ -322,13 +322,15 @@ module.exports = class RestNormalizer {
                 typeSparseFields = sparseFields[mapping.type];
             }
 
+            const mapContext = !isFnContext ? context : context(req, object);
+
             // map each attribute
             for (let i = 0, j = mapping.properties.length; i < j; i++) {
 
                 let property = mapping.properties[i];
 
                 if (typeof property.group !== 'undefined'
-                    && !property.group.read.includes(context)
+                    && !property.group.read.includes(mapContext)
                 ) {
                     continue;
                 }
@@ -348,9 +350,8 @@ module.exports = class RestNormalizer {
 
                         if (property.type === 'Date' && object[property.target] instanceof Date) {
 
-                            obj.attributes[property.attribute] = moment(
-                                object[property.target]
-                            ).format(property.format);
+                            obj.attributes[property.attribute] = moment(object[property.target])
+                                .format(property.format);
 
                         } else if ('valueMap' in property) {
 
@@ -362,7 +363,7 @@ module.exports = class RestNormalizer {
                                 req,
                                 route,
                                 val,
-                                !isFnContext ? context : context(req, val),
+                                mapContext,
                                 sparseFields,
                                 includes,
                                 included,

--- a/lib/specification/RestNormalizer.js
+++ b/lib/specification/RestNormalizer.js
@@ -199,6 +199,8 @@ module.exports = class RestNormalizer {
 
         let data = null;
 
+        const isFnContext = (typeof context === 'function');
+
         if (object === null) {
 
             return null;
@@ -212,7 +214,7 @@ module.exports = class RestNormalizer {
                     req,
                     route,
                     object[i],
-                    context,
+                    !isFnContext ? context : context(req, object[i]),
                     sparseFields,
                     includes,
                     included,
@@ -226,7 +228,7 @@ module.exports = class RestNormalizer {
                 req,
                 route,
                 object,
-                context,
+                !isFnContext ? context : context(req, object),
                 sparseFields,
                 includes,
                 included,
@@ -256,6 +258,8 @@ module.exports = class RestNormalizer {
 
         mapping = this.mapper.getMappingFromObject(object);
 
+        const isFnContext = (typeof context === 'function');
+
         // handle non-resources
         if (typeof mapping === 'undefined' || mapping === null) {
 
@@ -278,7 +282,7 @@ module.exports = class RestNormalizer {
                             req,
                             route,
                             object[idx],
-                            context,
+                            !isFnContext ? context : context(req, object[idx]),
                             sparseFields,
                             includes,
                             included,
@@ -358,7 +362,7 @@ module.exports = class RestNormalizer {
                                 req,
                                 route,
                                 val,
-                                context,
+                                !isFnContext ? context : context(req, val),
                                 sparseFields,
                                 includes,
                                 included,
@@ -412,7 +416,7 @@ module.exports = class RestNormalizer {
                                 req,
                                 route,
                                 object[relationship.target],
-                                context,
+                                !isFnContext ? context : context(req, object[relationship.target]),
                                 sparseFields,
                                 includes,
                                 included,
@@ -462,7 +466,7 @@ module.exports = class RestNormalizer {
                                     req,
                                     route,
                                     rel,
-                                    context,
+                                    !isFnContext ? context : context(req, rel),
                                     sparseFields,
                                     includes,
                                     included,

--- a/lib/specification/RestNormalizer.js
+++ b/lib/specification/RestNormalizer.js
@@ -199,8 +199,6 @@ module.exports = class RestNormalizer {
 
         let data = null;
 
-        const isFnContext = (typeof context === 'function');
-
         if (object === null) {
 
             return null;
@@ -214,7 +212,7 @@ module.exports = class RestNormalizer {
                     req,
                     route,
                     object[i],
-                    !isFnContext ? context : context(req, object[i]),
+                    context,
                     sparseFields,
                     includes,
                     included,
@@ -228,7 +226,7 @@ module.exports = class RestNormalizer {
                 req,
                 route,
                 object,
-                !isFnContext ? context : context(req, object),
+                context,
                 sparseFields,
                 includes,
                 included,
@@ -322,7 +320,7 @@ module.exports = class RestNormalizer {
                 typeSparseFields = sparseFields[mapping.type];
             }
 
-            const mapContext = !isFnContext ? context : context(req, object);
+            const mapContext = !isFnContext ? context : context(req, object, mapping.type);
 
             // map each attribute
             for (let i = 0, j = mapping.properties.length; i < j; i++) {
@@ -417,7 +415,12 @@ module.exports = class RestNormalizer {
                                 req,
                                 route,
                                 object[relationship.target],
-                                !isFnContext ? context : context(req, object[relationship.target]),
+                                !isFnContext ? context : context(
+                                    req,
+                                    object[relationship.target],
+                                    mapping.type,
+                                    relationship.relatedType
+                                ),
                                 sparseFields,
                                 includes,
                                 included,
@@ -467,7 +470,12 @@ module.exports = class RestNormalizer {
                                     req,
                                     route,
                                     rel,
-                                    !isFnContext ? context : context(req, rel),
+                                    !isFnContext ? context : context(
+                                        req,
+                                        rel,
+                                        mapping.type,
+                                        relationship.relatedType
+                                    ),
                                     sparseFields,
                                     includes,
                                     included,

--- a/lib/specification/basic/BasicMarshaller.js
+++ b/lib/specification/basic/BasicMarshaller.js
@@ -202,7 +202,7 @@ module.exports = class BasicMarshaller {
 
         const isFnGroup = (typeof group === 'function');
         const attrGroup = !isFnGroup ? group :
-            group(req, Object.assign({id: data.id}, data.attributes));
+            group(req, Object.assign({id: data.id}, data.attributes), mapping.type);
 
         for (attribute in data.attributes) {
 

--- a/lib/specification/basic/BasicMarshaller.js
+++ b/lib/specification/basic/BasicMarshaller.js
@@ -200,13 +200,17 @@ module.exports = class BasicMarshaller {
         let attribute;
         let map;
 
+        const isFnGroup = (typeof group === 'function');
+        const attrGroup = !isFnGroup ? group :
+            group(req, Object.assign({id: data.id}, data.attributes));
+
         for (attribute in data.attributes) {
 
             map = mapping.attributesToProperties[attribute];
 
             if (typeof map === 'undefined' ||
                 map.update === false ||
-                (typeof map.group !== 'undefined' && !map.group.write.includes(group))
+                (typeof map.group !== 'undefined' && !map.group.write.includes(attrGroup))
             ) {
 
             } else {

--- a/lib/specification/json-api/JsonApiErrorFormatter.js
+++ b/lib/specification/json-api/JsonApiErrorFormatter.js
@@ -22,7 +22,12 @@ module.exports = class JsonApiErrorFormatter {
             errors: []
         };
 
-        error.data.errors.forEach((err) => {
+        const errors = (
+            error.data.errors ||
+            error.data.originalError && error.data.originalError.data.errors
+        ) || [];
+
+        errors.forEach((err) => {
 
             // invalid query parameters
             if (err.type >= 300 && err.type < 400) {

--- a/lib/specification/json-api/JsonApiMarshaller.js
+++ b/lib/specification/json-api/JsonApiMarshaller.js
@@ -256,13 +256,17 @@ module.exports = class JsonApiMarshaller {
             object.id = data.id;
         }
 
+        const isFnGroup = (typeof group === 'function');
+        const attrGroup = !isFnGroup ? group :
+            group(req, Object.assign({id: data.id}, data.attributes));
+
         for (attribute in data.attributes) {
 
             map = mapping.attributesToProperties[attribute];
 
             if (typeof map === 'undefined' ||
                 map.update === false ||
-                (typeof map.group !== 'undefined' && !map.group.write.includes(group))
+                (typeof map.group !== 'undefined' && !map.group.write.includes(attrGroup))
             ) {
 
             } else {

--- a/lib/specification/json-api/JsonApiMarshaller.js
+++ b/lib/specification/json-api/JsonApiMarshaller.js
@@ -258,7 +258,7 @@ module.exports = class JsonApiMarshaller {
 
         const isFnGroup = (typeof group === 'function');
         const attrGroup = !isFnGroup ? group :
-            group(req, Object.assign({id: data.id}, data.attributes));
+            group(req, Object.assign({id: data.id}, data.attributes), mapping.type);
 
         for (attribute in data.attributes) {
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "pluralize": "^7.0.0"
   },
   "devDependencies": {
-    "@conga/framework-bass": "congajs/conga-bass#2.0.0-dev",
-    "@conga/framework-validation": "congajs/conga-validation#2.0.0-dev",
-    "bass": "latest",
-    "bass-nedb": "latest",
+    "@conga/framework-bass": "^2.0.0",
+    "@conga/framework-validation": "^2.0.0",
+    "bass": "^1.0.0",
+    "bass-nedb": "^1.0.0",
     "fs-extra": "^4.0.0",
     "jasmine": "^2.6.0",
     "query-string": "^4.3.4",


### PR DESCRIPTION
Added the ability to return a function for getGroupContext which gets called in the context of each resource that is being mapped.  This is needed for mapping security roles based on resource values, like `ROLE_WEBSITE_5` where 5 is the website id.  

Also fixed a few bugs and some clean up.

Example:

```
    /**
     * {@inheritDoc}
     * @see RestController.getGroupContext
     */
    getGroupContext(req, res) {
        return this.getGroupContextForResource.bind(this);
    }

    /**
     * Get the group context for a given resource in a given request
     * @param {Object} req The request object
     * @param {Object} resource The resource model
     * @param {String} [mappingType] The typeof document we are mapping for
     * @param {String} [relatedMappingType] The related document type we are mapping for (if this is given, it is the actual type being requested, and it is being mapped on an object of mappingType)
     * @returns {String}
     */
    getGroupContextForResource(
        req,
        resource,
        mappingType = this.resourceType,
        relatedMappingType = null
    ) {
        return this.getGroupContextFactory()
            .getGroupContextForResource(...arguments);
    }
```